### PR TITLE
Improve lexer perf for common cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 jpgo
 jmespath-fuzz.zip
+cpu.out
+go-jmespath.test

--- a/Makefile
+++ b/Makefile
@@ -36,3 +36,9 @@ buildfuzz:
 
 fuzz: buildfuzz
 	go-fuzz -bin=./jmespath-fuzz.zip -workdir=fuzz/corpus
+
+bench:
+	go test -bench . -cpuprofile cpu.out
+
+pprof-cpu:
+	go tool pprof ./go-jmespath.test ./cpu.out


### PR DESCRIPTION
Improves lexing for unquoted identifiers.
Also small perf improvement when consuming multiple string literals.

Improving the unquoted identifiers (probably the most common token in jmespath) improves many of the other benchmarks.  "old" is the latest commit on master and "new" is the latest commit on the lexer-perf branch:

```
benchmark                                 old ns/op     new ns/op     delta
BenchmarkLexIdentifier                    935           693           -25.88%
BenchmarkLexSubexpression                 1833          1309          -28.59%
BenchmarkLexDeeplyNested50                27043         21840         -19.24%
BenchmarkLexDeepNested50Pipe              27958         23265         -16.79%
BenchmarkLexQuotedIdentifier              2791          2621          -6.09%
BenchmarkLexQuotedIdentifierEscapes       3354          3211          -4.26%
BenchmarkLexRawStringLiteral              1776          1585          -10.75%
BenchmarkLexDeepProjection104             93516         78672         -15.87%
BenchmarkParseIdentifier                  1077          1055          -2.04%
BenchmarkParseSubexpression               2361          2190          -7.24%
BenchmarkParseDeeplyNested50              46356         41439         -10.61%
BenchmarkParseDeepNested50Pipe            43272         40188         -7.13%
BenchmarkParseQuotedIdentifier            2949          3144          +6.61%
BenchmarkParseQuotedIdentifierEscapes     3647          3735          +2.41%
BenchmarkParseRawStringLiteral            1979          1911          -3.44%
BenchmarkParseDeepProjection104           189288        176272        -6.88%
```