### PR TITLE
Improve error messages for syntax errors

### DIFF
--- a/cmd/jpgo/main.go
+++ b/cmd/jpgo/main.go
@@ -53,7 +53,10 @@ func run() int {
 	parser := jmespath.NewParser()
 	parsed, err := parser.Parse(expression)
 	if err != nil {
-		return errMsg("Error parsing expression (%s): %s", expression, err)
+		if syntaxError, ok := err.(jmespath.SyntaxError); ok {
+			return errMsg("%s\n%s\n", syntaxError, syntaxError.HighlightLocation())
+		}
+		return errMsg("%s", err)
 	}
 	if *astOnly {
 		pretty.Print(parsed)

--- a/compliance/slice.json
+++ b/compliance/slice.json
@@ -125,6 +125,10 @@
     {
       "expression": "foo[8:2&]",
       "error": "syntax"
+    },
+    {
+      "expression": "foo[2:a:3]",
+      "error": "syntax"
     }
   ]
 }, {

--- a/lexer.go
+++ b/lexer.go
@@ -225,7 +225,7 @@ func (lexer *Lexer) consumeUntil(end rune) (string, error) {
 	if lexer.lastWidth == 0 {
 		// Then we hit an EOF so we never reached the closing
 		// delimiter.
-		return "", &SyntaxError{
+		return "", SyntaxError{
 			msg:        "Unclosed delimiter: " + string(end),
 			Expression: lexer.expression,
 			Offset:     len(lexer.expression),
@@ -266,7 +266,7 @@ func (lexer *Lexer) consumeRawStringLiteral() (token, error) {
 	if lexer.lastWidth == 0 {
 		// Then we hit an EOF so we never reached the closing
 		// delimiter.
-		return token{}, &SyntaxError{
+		return token{}, SyntaxError{
 			msg:        "Unclosed delimiter: '",
 			Expression: lexer.expression,
 			Offset:     len(lexer.expression),

--- a/lexer.go
+++ b/lexer.go
@@ -38,7 +38,11 @@ type SyntaxError struct {
 func (e SyntaxError) Error() string {
 	// In the future, it would be good to underline the specific
 	// location where the error occurred.
-	return e.msg
+	return "SyntaxError: " + e.msg
+}
+
+func (e SyntaxError) HighlightLocation() string {
+	return e.Expression + "\n" + strings.Repeat(" ", e.Offset) + "^"
 }
 
 //go:generate stringer -type=tokType
@@ -286,7 +290,7 @@ func (lexer *Lexer) syntaxError(msg string) SyntaxError {
 	return SyntaxError{
 		msg:        msg,
 		Expression: lexer.expression,
-		Offset:     lexer.currentPos,
+		Offset:     lexer.currentPos - 1,
 	}
 }
 

--- a/parser.go
+++ b/parser.go
@@ -293,7 +293,7 @@ func (p *Parser) nud(token token) (ASTNode, error) {
 	case tQuotedIdentifier:
 		node := ASTNode{nodeType: ASTField, value: token.value}
 		if p.current() == tLparen {
-			return ASTNode{}, p.syntaxError("Can't have quoted identifier as function name.")
+			return ASTNode{}, p.syntaxErrorToken("Can't have quoted identifier as function name.", token)
 		}
 		return node, nil
 	case tStar:
@@ -349,10 +349,10 @@ func (p *Parser) nud(token token) (ASTNode, error) {
 		expression, err := p.parseExpression(bindingPowers[tExpref])
 		return ASTNode{nodeType: ASTExpRef, children: []ASTNode{expression}}, err
 	case tEOF:
-		return ASTNode{}, SyntaxError{msg: "Incomplete expression", Expression: p.expression, Offset: token.position}
+		return ASTNode{}, p.syntaxErrorToken("Incomplete expression", token)
 	}
 
-	return ASTNode{}, p.syntaxError("Invalid token")
+	return ASTNode{}, p.syntaxErrorToken("Invalid token: "+token.tokenType.String(), token)
 }
 
 func (p *Parser) parseMultiSelectList() (ASTNode, error) {
@@ -530,5 +530,16 @@ func (p *Parser) syntaxError(msg string) SyntaxError {
 		msg:        msg,
 		Expression: p.expression,
 		Offset:     p.lookaheadToken(0).position,
+	}
+}
+
+// Create a SyntaxError based on the provided token.
+// This differs from syntaxError() which creates a SyntaxError
+// based on the current lookahead token.
+func (p *Parser) syntaxErrorToken(msg string, t token) SyntaxError {
+	return SyntaxError{
+		msg:        msg,
+		Expression: p.expression,
+		Offset:     t.position,
 	}
 }


### PR DESCRIPTION
Now you'll get:

```
$ ./jpgo -ast '`foo'
SyntaxError: Unclosed delimiter: `
`foo
    ^
$ ./jpgo -ast 'foo[]]'
SyntaxError: Unexpected token at the end of the expresssion: tRbracket
foo[]]
     ^
$ ./jpgo -ast 'foo[0:bar:]'
SyntaxError: Expected tColon or tNumber, received: tUnquotedIdentifier
foo[0:bar:]
      ^

```