### PR TITLE
Add a proper pretty printed AST node

### DIFF
--- a/cmd/jpgo/main.go
+++ b/cmd/jpgo/main.go
@@ -27,7 +27,6 @@ import (
 	"encoding/json"
 
 	"github.com/jmespath/go-jmespath"
-	"github.com/kr/pretty"
 )
 
 func errMsg(msg string, a ...interface{}) int {
@@ -59,8 +58,8 @@ func run() int {
 		return errMsg("%s", err)
 	}
 	if *astOnly {
-		pretty.Print(parsed)
 		fmt.Println("")
+		fmt.Printf("%s\n", parsed)
 		return 0
 	}
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -35,6 +35,63 @@ func TestParsingErrors(t *testing.T) {
 	}
 }
 
+var prettyPrinted = `ASTProjection {
+  children: {
+    ASTField {
+      value: "foo"
+    }
+    ASTSubexpression {
+      children: {
+        ASTSubexpression {
+          children: {
+            ASTField {
+              value: "bar"
+            }
+            ASTField {
+              value: "baz"
+            }
+        }
+        ASTField {
+          value: "qux"
+        }
+    }
+}
+`
+
+var prettyPrintedCompNode = `ASTFilterProjection {
+  children: {
+    ASTField {
+      value: "a"
+    }
+    ASTIdentity {
+    }
+    ASTComparator {
+      value: tLTE
+      children: {
+        ASTField {
+          value: "b"
+        }
+        ASTField {
+          value: "c"
+        }
+    }
+}
+`
+
+func TestPrettyPrintedAST(t *testing.T) {
+	assert := assert.New(t)
+	parser := NewParser()
+	parsed, _ := parser.Parse("foo[*].bar.baz.qux")
+	assert.Equal(parsed.PrettyPrint(0), prettyPrinted)
+}
+
+func TestPrettyPrintedCompNode(t *testing.T) {
+	assert := assert.New(t)
+	parser := NewParser()
+	parsed, _ := parser.Parse("a[?b<=c]")
+	assert.Equal(parsed.PrettyPrint(0), prettyPrintedCompNode)
+}
+
 func BenchmarkParseIdentifier(b *testing.B) {
 	runParseBenchmark(b, exprIdentifier)
 }


### PR DESCRIPTION
Examples:

```
./jpgo -ast 'a[?b<=c]'

ASTFilterProjection {
  children: {
    ASTField {
      value: "a"
    }
    ASTIdentity {
    }
    ASTComparator {
      value: tLTE
      children: {
        ASTField {
          value: "b"
        }
        ASTField {
          value: "c"
        }
    }
}

```