### PR TITLE
Add testcase to interpreter searching for multiple values in a slice.

### DIFF
--- a/interpreter_test.go
+++ b/interpreter_test.go
@@ -63,6 +63,14 @@ func TestCanSupportUserDefinedStructsRef(t *testing.T) {
 	assert.Equal("one", result)
 }
 
+func TestCanSupportStructWithSliceAll(t *testing.T) {
+	assert := assert.New(t)
+	data := sliceType{A: "foo", B: []scalars{scalars{"f1", "b1"}, scalars{"correct", "b2"}}}
+	result, err := Search("B[].Foo", data)
+	assert.Nil(err)
+	assert.Equal([]interface{}{"f1", "correct"}, result)
+}
+
 func TestCanSupportStructWithSlice(t *testing.T) {
 	assert := assert.New(t)
 	data := sliceType{A: "foo", B: []scalars{scalars{"f1", "b1"}, scalars{"correct", "b2"}}}


### PR DESCRIPTION
Looks like there is a bug preventing multiple values being returned from a query. The added test case highlights this issue.