### PR TITLE
Add support for missing cases with user defined structs

### DIFF
--- a/interpreter.go
+++ b/interpreter.go
@@ -316,6 +316,9 @@ func (intr *treeInterpreter) fieldFromStruct(key string, value interface{}) (int
 		return v.Interface(), nil
 	} else if rv.Kind() == reflect.Ptr {
 		// Handle multiple levels of indirection?
+		if rv.IsNil() {
+			return nil, nil
+		}
 		rv = rv.Elem()
 		v := rv.FieldByName(fieldName)
 		if !v.IsValid() {

--- a/interpreter_test.go
+++ b/interpreter_test.go
@@ -95,6 +95,14 @@ func TestCanSupportStructWithSlice(t *testing.T) {
 	assert.Equal("correct", result)
 }
 
+func TestCanSupportStructWithOrExpressions(t *testing.T) {
+	assert := assert.New(t)
+	data := sliceType{A: "foo", C: nil}
+	result, err := Search("C || A", data)
+	assert.Nil(err)
+	assert.Equal("foo", result)
+}
+
 func TestCanSupportStructWithSlicePointer(t *testing.T) {
 	assert := assert.New(t)
 	data := sliceType{A: "foo", C: []*scalars{&scalars{"f1", "b1"}, &scalars{"correct", "b2"}}}

--- a/interpreter_test.go
+++ b/interpreter_test.go
@@ -63,6 +63,14 @@ func TestCanSupportUserDefinedStructsRef(t *testing.T) {
 	assert.Equal("one", result)
 }
 
+func TestCanSupportStructWithSliceAll(t *testing.T) {
+	assert := assert.New(t)
+	data := sliceType{A: "foo", B: []scalars{scalars{"f1", "b1"}, scalars{"correct", "b2"}}}
+	result, err := Search("B[].Foo", data)
+	assert.Nil(err)
+	assert.Equal([]interface{}{"f1", "correct"}, result)
+}
+
 func TestCanSupportStructWithSlice(t *testing.T) {
 	assert := assert.New(t)
 	data := sliceType{A: "foo", B: []scalars{scalars{"f1", "b1"}, scalars{"correct", "b2"}}}

--- a/interpreter_test.go
+++ b/interpreter_test.go
@@ -130,6 +130,14 @@ func TestCanSupportStructWithSliceLowerCased(t *testing.T) {
 	assert.Equal("correct", result)
 }
 
+func TestCanSupportStructWithNestedPointers(t *testing.T) {
+	assert := assert.New(t)
+	data := struct{ A *struct{ B int } }{}
+	result, err := Search("A.B", data)
+	assert.Nil(err)
+	assert.Nil(result)
+}
+
 func BenchmarkInterpretSingleFieldStruct(b *testing.B) {
 	intr := newInterpreter()
 	parser := NewParser()

--- a/interpreter_test.go
+++ b/interpreter_test.go
@@ -71,6 +71,22 @@ func TestCanSupportStructWithSliceAll(t *testing.T) {
 	assert.Equal([]interface{}{"f1", "correct"}, result)
 }
 
+func TestCanSupportStructWithSlicingExpression(t *testing.T) {
+	assert := assert.New(t)
+	data := sliceType{A: "foo", B: []scalars{scalars{"f1", "b1"}, scalars{"correct", "b2"}}}
+	result, err := Search("B[:].Foo", data)
+	assert.Nil(err)
+	assert.Equal([]interface{}{"f1", "correct"}, result)
+}
+
+func TestCanSupportStructWithFilterProjection(t *testing.T) {
+	assert := assert.New(t)
+	data := sliceType{A: "foo", B: []scalars{scalars{"f1", "b1"}, scalars{"correct", "b2"}}}
+	result, err := Search("B[? `true` ].Foo", data)
+	assert.Nil(err)
+	assert.Equal([]interface{}{"f1", "correct"}, result)
+}
+
 func TestCanSupportStructWithSlice(t *testing.T) {
 	assert := assert.New(t)
 	data := sliceType{A: "foo", B: []scalars{scalars{"f1", "b1"}, scalars{"correct", "b2"}}}

--- a/util.go
+++ b/util.go
@@ -11,6 +11,13 @@ import (
 // - The boolean value false.
 // - nil
 func isFalse(value interface{}) bool {
+	/*
+		TODO:  you might be able to do:
+		       needed for all the user defined structs.
+		zeroValue := reflect.Zero(reflect.ValueOf(value).Type())
+		return zeroValue.Interface() == value
+	*/
+
 	switch v := value.(type) {
 	case bool:
 		return !v
@@ -157,4 +164,11 @@ func toArrayStr(data interface{}) ([]string, bool) {
 		return result, true
 	}
 	return nil, false
+}
+
+func isSliceType(v interface{}) bool {
+	if v == nil {
+		return false
+	}
+	return reflect.TypeOf(v).Kind() == reflect.Slice
 }

--- a/util.go
+++ b/util.go
@@ -30,7 +30,7 @@ func isFalse(value interface{}) bool {
 		// A struct type will never be false, even if
 		// all of its values are the zero type.
 		return false
-	} else if vType == reflect.Slice {
+	} else if vType == reflect.Slice || vType == reflect.Map {
 		if v.Len() == 0 {
 			return true
 		}

--- a/util.go
+++ b/util.go
@@ -11,13 +11,6 @@ import (
 // - The boolean value false.
 // - nil
 func isFalse(value interface{}) bool {
-	/*
-		TODO:  you might be able to do:
-		       needed for all the user defined structs.
-		zeroValue := reflect.Zero(reflect.ValueOf(value).Type())
-		return zeroValue.Interface() == value
-	*/
-
 	switch v := value.(type) {
 	case bool:
 		return !v
@@ -29,6 +22,23 @@ func isFalse(value interface{}) bool {
 		return len(v) == 0
 	case nil:
 		return true
+	}
+	// Try the reflection cases before returning false.
+	vType := reflect.TypeOf(value).Kind()
+	if vType == reflect.Struct {
+		// A struct type will never be false, even if
+		// all of its values are the zero type.
+		return false
+	} else if vType == reflect.Slice {
+		if reflect.ValueOf(value).Len() == 0 {
+			return true
+		}
+		return false
+	} else if vType == reflect.Ptr {
+		// If it's a pointer type, we'll try to deref the pointer
+		// and evaluate the pointer value for isFalse.
+		v := reflect.ValueOf(value).Elem()
+		return isFalse(v.Interface())
 	}
 	return false
 }

--- a/util.go
+++ b/util.go
@@ -24,21 +24,25 @@ func isFalse(value interface{}) bool {
 		return true
 	}
 	// Try the reflection cases before returning false.
-	vType := reflect.TypeOf(value).Kind()
+	v := reflect.ValueOf(value)
+	vType := v.Type().Kind()
 	if vType == reflect.Struct {
 		// A struct type will never be false, even if
 		// all of its values are the zero type.
 		return false
 	} else if vType == reflect.Slice {
-		if reflect.ValueOf(value).Len() == 0 {
+		if v.Len() == 0 {
 			return true
 		}
 		return false
 	} else if vType == reflect.Ptr {
+		if v.IsNil() {
+			return true
+		}
 		// If it's a pointer type, we'll try to deref the pointer
 		// and evaluate the pointer value for isFalse.
-		v := reflect.ValueOf(value).Elem()
-		return isFalse(v.Interface())
+		element := v.Elem()
+		return isFalse(element.Interface())
 	}
 	return false
 }

--- a/util.go
+++ b/util.go
@@ -24,24 +24,21 @@ func isFalse(value interface{}) bool {
 		return true
 	}
 	// Try the reflection cases before returning false.
-	v := reflect.ValueOf(value)
-	vType := v.Type().Kind()
-	if vType == reflect.Struct {
+	rv := reflect.ValueOf(value)
+	switch rv.Kind() {
+	case reflect.Struct:
 		// A struct type will never be false, even if
 		// all of its values are the zero type.
 		return false
-	} else if vType == reflect.Slice || vType == reflect.Map {
-		if v.Len() == 0 {
-			return true
-		}
-		return false
-	} else if vType == reflect.Ptr {
-		if v.IsNil() {
+	case reflect.Slice, reflect.Map:
+		return rv.Len() == 0
+	case reflect.Ptr:
+		if rv.IsNil() {
 			return true
 		}
 		// If it's a pointer type, we'll try to deref the pointer
 		// and evaluate the pointer value for isFalse.
-		element := v.Elem()
+		element := rv.Elem()
 		return isFalse(element.Interface())
 	}
 	return false

--- a/util_test.go
+++ b/util_test.go
@@ -51,6 +51,16 @@ func TestIsFalseWithNilInterface(t *testing.T) {
 	assert.True(isFalse(nilInterface))
 }
 
+func TestIsFalseWithMapOfUserStructs(t *testing.T) {
+	assert := assert.New(t)
+	type foo struct {
+		Bar string
+		Baz string
+	}
+	m := make(map[int]foo)
+	assert.True(isFalse(m))
+}
+
 func TestObjsEqual(t *testing.T) {
 	assert := assert.New(t)
 	assert.True(objsEqual("foo", "foo"))

--- a/util_test.go
+++ b/util_test.go
@@ -1,9 +1,8 @@
 package jmespath
 
 import (
-	"testing"
-
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 func TestSlicePositiveStep(t *testing.T) {
@@ -42,6 +41,14 @@ func TestIsFalseWithUserDefinedStructs(t *testing.T) {
 	// A user defined struct will never be false though,
 	// even if it's fields are the zero type.
 	assert.False(isFalse(nilStruct))
+}
+
+func TestIsFalseWithNilInterface(t *testing.T) {
+	assert := assert.New(t)
+	var a *int = nil
+	var nilInterface interface{}
+	nilInterface = a
+	assert.True(isFalse(nilInterface))
 }
 
 func TestObjsEqual(t *testing.T) {

--- a/util_test.go
+++ b/util_test.go
@@ -19,7 +19,7 @@ func TestSlicePositiveStep(t *testing.T) {
 	assert.Equal(input[:3], result)
 }
 
-func TestIsFalse(t *testing.T) {
+func TestIsFalseJSONTypes(t *testing.T) {
 	assert := assert.New(t)
 	assert.True(isFalse(false))
 	assert.True(isFalse(""))
@@ -28,6 +28,20 @@ func TestIsFalse(t *testing.T) {
 	m := make(map[string]interface{})
 	assert.True(isFalse(m))
 	assert.True(isFalse(nil))
+
+}
+
+func TestIsFalseWithUserDefinedStructs(t *testing.T) {
+	assert := assert.New(t)
+	type nilStructType struct {
+		SliceOfPointers []*string
+	}
+	nilStruct := nilStructType{SliceOfPointers: nil}
+	assert.True(isFalse(nilStruct.SliceOfPointers))
+
+	// A user defined struct will never be false though,
+	// even if it's fields are the zero type.
+	assert.False(isFalse(nilStruct))
 }
 
 func TestObjsEqual(t *testing.T) {


### PR DESCRIPTION
Fixes the failing test case from https://github.com/jmespath/go-jmespath/pull/8 and fleshes out additional missing cases when using user defined structs for these additional missing cases:

* slices: `foo[:].bar`
* filter projections: ``foo[? `true`].bar``

I also needed to update `isFalse` to account for user defined structs:

* Handle a slice of user defined types
* Handle structures (these will always be true)
* Handle pointers by comparing `isFalse` against the dereferenced pointer value.

I also tried to keep the reflection vs. map interface code paths completely separate to ensure that we're not slowing down the case when a user uses the emtpy interface with `json.Unmarshal`.

cc @jasdel