### PR TITLE
Account for reflection code path in list to flatten

### DIFF
--- a/interpreter.go
+++ b/interpreter.go
@@ -130,6 +130,13 @@ func (intr *treeInterpreter) Execute(node ASTNode, value interface{}) (interface
 		for _, element := range sliceType {
 			if elementSlice, ok := element.([]interface{}); ok {
 				flattened = append(flattened, elementSlice...)
+			} else if isSliceType(element) {
+				reflectFlat := make([]interface{}, 0, 0)
+				v := reflect.ValueOf(element)
+				for i := 0; i < v.Len(); i++ {
+					reflectFlat = append(reflectFlat, v.Index(i).Interface())
+				}
+				flattened = append(flattened, reflectFlat...)
 			} else {
 				flattened = append(flattened, element)
 			}

--- a/interpreter_test.go
+++ b/interpreter_test.go
@@ -38,6 +38,10 @@ type nestedC struct {
 	Fooasdfasdfasdfasdf string
 }
 
+type nestedSlice struct {
+	A []sliceType
+}
+
 func TestCanSupportEmptyInterface(t *testing.T) {
 	assert := assert.New(t)
 	data := make(map[string]interface{})
@@ -136,6 +140,17 @@ func TestCanSupportStructWithNestedPointers(t *testing.T) {
 	result, err := Search("A.B", data)
 	assert.Nil(err)
 	assert.Nil(result)
+}
+
+func TestCanSupportFlattenNestedSlice(t *testing.T) {
+	assert := assert.New(t)
+	data := nestedSlice{A: []sliceType{
+		{B: []scalars{{Foo: "f1a"}, {Foo: "f1b"}}},
+		{B: []scalars{{Foo: "f2a"}, {Foo: "f2b"}}},
+	}}
+	result, err := Search("A[].B[].Foo", data)
+	assert.Nil(err)
+	assert.Equal([]interface{}{"f1a", "f1b", "f2a", "f2b"}, result)
 }
 
 func BenchmarkInterpretSingleFieldStruct(b *testing.B) {

--- a/interpreter_test.go
+++ b/interpreter_test.go
@@ -153,6 +153,16 @@ func TestCanSupportFlattenNestedSlice(t *testing.T) {
 	assert.Equal([]interface{}{"f1a", "f1b", "f2a", "f2b"}, result)
 }
 
+func TestCanSupportProjectionsWithStructs(t *testing.T) {
+	assert := assert.New(t)
+	data := nestedSlice{A: []sliceType{
+		{A: "first"}, {A: "second"}, {A: "third"},
+	}}
+	result, err := Search("A[*].A", data)
+	assert.Nil(err)
+	assert.Equal([]interface{}{"first", "second", "third"}, result)
+}
+
 func BenchmarkInterpretSingleFieldStruct(b *testing.B) {
 	intr := newInterpreter()
 	parser := NewParser()


### PR DESCRIPTION
The previous fix for user provided structs checked the
type of the parent type before deciding what code path
to go down.  We also need to account for the individual
array elements also requiring a reflection code path.

Fixes #10.


I also fixed the same issue with bare projections.

I also audited all the type conversions to make sure there were no remaining cases:

```
$ ag -A 2 '\(\[\]interface{}\)' interpreter.go
89:          sliceType, ok := left.([]interface{})
90-          if !ok {
91-                  if isSliceType(left) {
119:         sliceType, ok := left.([]interface{})
120-         if !ok {
121-                 // If we can't type convert to []interface{}, there's
131:                 if elementSlice, ok := element.([]interface{}); ok {
132-                         flattened = append(flattened, elementSlice...)
133-                 } else if isSliceType(element) {
148:         if sliceType, ok := value.([]interface{}); ok {
149-                 index := node.value.(int)
150-                 if index < 0 {
247:         sliceType, ok := left.([]interface{})
248-         if !ok {
249-                 if isSliceType(left) {
273:         sliceType, ok := value.([]interface{})
274-         if !ok {
275-                 if isSliceType(value) {
```

cc @jasdel 