### PR TITLE
Pointer scalars

### DIFF
--- a/interpreter.go
+++ b/interpreter.go
@@ -314,27 +314,56 @@ func (intr *treeInterpreter) Execute(node ASTNode, value interface{}) (interface
 	return nil, errors.New("Unknown AST node: " + node.nodeType.String())
 }
 
+func fieldFromStruct(value reflect.Value, fieldName string) interface{} {
+	v := value.FieldByName(fieldName)
+	if !v.IsValid() {
+		return nil
+	}
+
+	switch v := v.Interface().(type) {
+	case *string:
+		return *v
+	case *int:
+		return *v
+	case *int8:
+		return *v
+	case *int16:
+		return *v
+	case *int32:
+		return *v
+	case *int64:
+		return *v
+	case *uint:
+		return *v
+	case *uint8:
+		return *v
+	case *uint16:
+		return *v
+	case *uint32:
+		return *v
+	case *uint64:
+		return *v
+	case *float32:
+		return *v
+	case *float64:
+		return *v
+	default:
+		return v
+	}
+}
+
 func (intr *treeInterpreter) fieldFromStruct(key string, value interface{}) (interface{}, error) {
 	rv := reflect.ValueOf(value)
 	first, n := utf8.DecodeRuneInString(key)
 	fieldName := string(unicode.ToUpper(first)) + key[n:]
 	if rv.Kind() == reflect.Struct {
-		v := rv.FieldByName(fieldName)
-		if !v.IsValid() {
-			return nil, nil
-		}
-		return v.Interface(), nil
+		return fieldFromStruct(rv, fieldName), nil
 	} else if rv.Kind() == reflect.Ptr {
 		// Handle multiple levels of indirection?
 		if rv.IsNil() {
 			return nil, nil
 		}
-		rv = rv.Elem()
-		v := rv.FieldByName(fieldName)
-		if !v.IsValid() {
-			return nil, nil
-		}
-		return v.Interface(), nil
+		return fieldFromStruct(rv.Elem(), fieldName), nil
 	}
 	return nil, nil
 }

--- a/interpreter_test.go
+++ b/interpreter_test.go
@@ -12,6 +12,11 @@ type scalars struct {
 	Bar string
 }
 
+type pointerScalars struct {
+	Foo *string
+	Bar *int64
+}
+
 type sliceType struct {
 	A string
 	B []scalars
@@ -113,6 +118,19 @@ func TestCanSupportStructWithSlicePointer(t *testing.T) {
 	result, err := Search("C[-1].Foo", data)
 	assert.Nil(err)
 	assert.Equal("correct", result)
+}
+
+func TestCanSupportStructWithPointerScalars(t *testing.T) {
+	assert := assert.New(t)
+	foo := "foo"
+	bar := int64(124)
+	data := pointerScalars{Foo: &foo, Bar: &bar}
+	result, err := Search("Foo", data)
+	assert.Nil(err)
+	assert.Equal("foo", result)
+	result, err = Search("Bar", data)
+	assert.Nil(err)
+	assert.Equal(124, result)
 }
 
 func TestWillAutomaticallyCapitalizeFieldNames(t *testing.T) {

--- a/interpreter_test.go
+++ b/interpreter_test.go
@@ -21,6 +21,7 @@ type sliceType struct {
 	A string
 	B []scalars
 	C []*scalars
+	D []*pointerScalars
 }
 
 type benchmarkStruct struct {
@@ -130,7 +131,20 @@ func TestCanSupportStructWithPointerScalars(t *testing.T) {
 	assert.Equal("foo", result)
 	result, err = Search("Bar", data)
 	assert.Nil(err)
-	assert.Equal(124, result)
+	assert.Equal(int64(124), result)
+}
+
+func TestCanSupportStructRefWithPointerScalars(t *testing.T) {
+	assert := assert.New(t)
+	foo := "foo"
+	bar := int64(124)
+	data := sliceType{D: []*pointerScalars{&pointerScalars{Foo: &foo, Bar: &bar}}}
+	result, err := Search("D[0].Foo", data)
+	assert.Nil(err)
+	assert.Equal("foo", result)
+	result, err = Search("D[0].Bar", data)
+	assert.Nil(err)
+	assert.Equal(int64(124), result)
 }
 
 func TestWillAutomaticallyCapitalizeFieldNames(t *testing.T) {


### PR DESCRIPTION
This is a failing test for the cause of the issue mentioned in https://github.com/aws/aws-sdk-go/issues/457 and https://github.com/jmespath/go-jmespath/issues/14.

I've added a potential implementation that fixes the tests, but I'm not super happy with having to type switch against all the basic scalars in Go.