### PR TITLE
Use reflection to type check for slice types

### DIFF
--- a/functions.go
+++ b/functions.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -357,7 +358,7 @@ func (a *argSpec) typeCheck(arg interface{}) error {
 				return nil
 			}
 		case jpArray:
-			if _, ok := arg.([]interface{}); ok {
+			if isSliceType(arg) {
 				return nil
 			}
 		case jpObject:
@@ -409,8 +410,9 @@ func jpfLength(arguments []interface{}) (interface{}, error) {
 	arg := arguments[0]
 	if c, ok := arg.(string); ok {
 		return float64(utf8.RuneCountInString(c)), nil
-	} else if c, ok := arg.([]interface{}); ok {
-		return float64(len(c)), nil
+	} else if isSliceType(arg) {
+		v := reflect.ValueOf(arg)
+		return float64(v.Len()), nil
 	} else if c, ok := arg.(map[string]interface{}); ok {
 		return float64(len(c)), nil
 	}

--- a/interpreter_test.go
+++ b/interpreter_test.go
@@ -205,6 +205,14 @@ func TestCanSupportProjectionsWithStructs(t *testing.T) {
 	assert.Equal([]interface{}{"first", "second", "third"}, result)
 }
 
+func TestCanSupportSliceOfStructsWithFunctions(t *testing.T) {
+	assert := assert.New(t)
+	data := []scalars{scalars{"a1", "b1"}, scalars{"a2", "b2"}}
+	result, err := Search("length(@)", data)
+	assert.Nil(err)
+	assert.Equal(result.(float64), 2.0)
+}
+
 func BenchmarkInterpretSingleFieldStruct(b *testing.B) {
 	intr := newInterpreter()
 	parser := NewParser()


### PR DESCRIPTION
Fixed the length() function to work with a slice
of structs.

The entire functions.go will need an audit to update
the code to not assume slice of empty interface.

Related: #15.

Note:  I'll use this PR as a working branch as I audit all the remaining functions, but I wanted to get the initial PR started.  The remaining functions will likely go through a similar change.

I also want to see if there's a way I can auto gen compliance tests that use structs instead of empty interface so I can leverage the existing test code I have.

cc @jasdel 