### PR TITLE
Anchor jpgo in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-jpgo
+/jpgo
 jmespath-fuzz.zip
 cpu.out
 go-jmespath.test


### PR DESCRIPTION
There is currently a line `jpgo` in the .gitignore file. It is intended
to ignore the binary built with `make build`. While it works for that
purpose, because the line does not start with `/` it also ignores ANY
`jpgo` anywhere in the tree. Including `cmd/jpgo`. If you add a new
file, say `touch cmd/jpgo/testfile`, and then check the git status you
will see that git ignored the new file because the `cmd/jpgo` directory
is being ignored.

This patch anchors the gitignore line so it looks like: `/jpgo` so that
only jpgo in the root of the tree will be ignored. This also will
prevent others running into problems like the incomplete `git add` we
hit in https://github.com/kubernetes/kubernetes/pull/24242 when
vendoring go-jmespath