### PR TITLE
Resolve pointer chains while fetching children from objects

### DIFF
--- a/pointers_test.go
+++ b/pointers_test.go
@@ -1,0 +1,44 @@
+package jmespath
+
+import (
+	// "fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPointerObj(t *testing.T) {
+	assert := assert.New(t)
+	testval := float64(10)
+	testvalPtr := &testval
+	obj := map[string]interface{} {
+		"keyPtr": testvalPtr,
+	}
+	result, err := Search("keyPtr==`10`", obj)
+	assert.True(result.(bool))
+	assert.Nil(err)
+}
+
+func TestPointerChain(t *testing.T) {
+	assert := assert.New(t)
+	v1 := interface{}(float64(10))
+	v2 := &v1
+	v3 := interface{}(v2)
+	v4 := &v3
+	obj := map[string]interface{} {
+		"keyPtr": v4,
+	}
+	result, err := Search("keyPtr==`10`", obj)
+	assert.True(result.(bool))
+	assert.Nil(err)
+}
+
+func TestPointerObscured(t *testing.T) {
+	assert := assert.New(t)
+	obj := map[string]interface{} {
+		"keyPtr": float64(10),
+	}
+	result, err := Search("keyPtr==`10`", interface{}(&obj))
+	assert.True(result.(bool))
+	assert.Nil(err)
+}

--- a/util.go
+++ b/util.go
@@ -183,3 +183,22 @@ func isSliceType(v interface{}) bool {
 	}
 	return reflect.TypeOf(v).Kind() == reflect.Slice
 }
+
+func stripPtrs(rv reflect.Value) (reflect.Value, error) {
+	// Some pointer chains are disguised as interface
+	if rv.Kind() == reflect.Interface {
+		// Try to reassess type
+		rv = reflect.ValueOf(rv.Interface())
+	}
+	for rv.Kind() == reflect.Ptr {
+		if rv.IsNil() {
+			return rv, errors.New("Pointer is nil")
+		}
+		rv = rv.Elem()
+		if rv.Kind() == reflect.Interface {
+			// Try to reassess type
+			rv = reflect.ValueOf(rv.Interface())
+		}
+	}
+	return rv, nil
+}


### PR DESCRIPTION
While this shouldn't be an issue when running queries on an object directly Unmarshaled by `encoding/json`, but after the object has been modified a bit (including the use of jmespath) there is a chance that child objects are hidden behind pointer references (even multiple ones).

For my use case I had to strip the parent and the child of pointer references for both map and struct. Failure test cases are also part of this pull request.

This also resolves the todo `Handle multiple levels of indirection?`