### PR TITLE
rolling back pointer changes

### DIFF
--- a/interpreter.go
+++ b/interpreter.go
@@ -76,7 +76,11 @@ func (intr *treeInterpreter) Execute(node ASTNode, value interface{}) (interface
 		}
 		return intr.fCall.CallFunction(node.value.(string), resolvedArgs, intr)
 	case ASTField:
-		return intr.fieldFromStructOrMap(node.value.(string), value)
+		if m, ok := value.(map[string]interface{}); ok {
+			key := node.value.(string)
+			return m[key], nil
+		}
+		return intr.fieldFromStruct(node.value.(string), value)
 	case ASTFilterProjection:
 		left, err := intr.Execute(node.children[0], value)
 		if err != nil {
@@ -310,14 +314,8 @@ func (intr *treeInterpreter) Execute(node ASTNode, value interface{}) (interface
 	return nil, errors.New("Unknown AST node: " + node.nodeType.String())
 }
 
-func (intr *treeInterpreter) fieldFromStructOrMap(key string, value interface{}) (interface{}, error) {
-	var err error
+func (intr *treeInterpreter) fieldFromStruct(key string, value interface{}) (interface{}, error) {
 	rv := reflect.ValueOf(value)
-	rv, err = stripPtrs(rv)
-	if err != nil {
-		return nil, nil
-	}
-
 	first, n := utf8.DecodeRuneInString(key)
 	fieldName := string(unicode.ToUpper(first)) + key[n:]
 	if rv.Kind() == reflect.Struct {
@@ -325,24 +323,19 @@ func (intr *treeInterpreter) fieldFromStructOrMap(key string, value interface{})
 		if !v.IsValid() {
 			return nil, nil
 		}
-		v, err = stripPtrs(v)
-		if err != nil {
+		return v.Interface(), nil
+	} else if rv.Kind() == reflect.Ptr {
+		// Handle multiple levels of indirection?
+		if rv.IsNil() {
+			return nil, nil
+		}
+		rv = rv.Elem()
+		v := rv.FieldByName(fieldName)
+		if !v.IsValid() {
 			return nil, nil
 		}
 		return v.Interface(), nil
-	} else if rv.Kind() == reflect.Map {
-		field := rv.MapIndex(reflect.ValueOf(key))
-		field, err = stripPtrs(field)
-		if err != nil {
-			return nil, nil
-		}
-		if field.IsValid() {
-			return field.Interface(), nil
-		} else {
-			return nil, nil
-		}
 	}
-
 	return nil, nil
 }
 

--- a/interpreter_test.go
+++ b/interpreter_test.go
@@ -181,42 +181,6 @@ func TestCanSupportSliceOfStructsWithFunctions(t *testing.T) {
 	assert.Equal(result.(float64), 2.0)
 }
 
-func TestPointerObj(t *testing.T) {
-	assert := assert.New(t)
-	testval := float64(10)
-	testvalPtr := &testval
-	obj := map[string]interface{}{
-		"keyPtr": testvalPtr,
-	}
-	result, err := Search("keyPtr==`10`", obj)
-	assert.True(result.(bool))
-	assert.Nil(err)
-}
-
-func TestPointerChain(t *testing.T) {
-	assert := assert.New(t)
-	v1 := interface{}(float64(10))
-	v2 := &v1
-	v3 := interface{}(v2)
-	v4 := &v3
-	obj := map[string]interface{}{
-		"keyPtr": v4,
-	}
-	result, err := Search("keyPtr==`10`", obj)
-	assert.True(result.(bool))
-	assert.Nil(err)
-}
-
-func TestPointerObscured(t *testing.T) {
-	assert := assert.New(t)
-	obj := map[string]interface{}{
-		"keyPtr": float64(10),
-	}
-	result, err := Search("keyPtr==`10`", interface{}(&obj))
-	assert.True(result.(bool))
-	assert.Nil(err)
-}
-
 func BenchmarkInterpretSingleFieldStruct(b *testing.B) {
 	intr := newInterpreter()
 	parser := NewParser()

--- a/util.go
+++ b/util.go
@@ -183,22 +183,3 @@ func isSliceType(v interface{}) bool {
 	}
 	return reflect.TypeOf(v).Kind() == reflect.Slice
 }
-
-func stripPtrs(rv reflect.Value) (reflect.Value, error) {
-	// Some pointer chains are disguised as interface
-	if rv.Kind() == reflect.Interface {
-		// Try to reassess type
-		rv = reflect.ValueOf(rv.Interface())
-	}
-	for rv.Kind() == reflect.Ptr {
-		if rv.IsNil() {
-			return rv, errors.New("Pointer is nil")
-		}
-		rv = rv.Elem()
-		if rv.Kind() == reflect.Interface {
-			// Try to reassess type
-			rv = reflect.ValueOf(rv.Interface())
-		}
-	}
-	return rv, nil
-}

--- a/util_test.go
+++ b/util_test.go
@@ -1,7 +1,6 @@
 package jmespath
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -72,14 +71,4 @@ func TestObjsEqual(t *testing.T) {
 	assert.True(!objsEqual(nil, "foo"))
 	assert.True(objsEqual([]int{}, []int{}))
 	assert.True(!objsEqual([]int{}, nil))
-}
-
-func TestStripPtrs(t *testing.T) {
-	assert := assert.New(t)
-	v1 := interface{}(1.0)
-	v2 := &v1
-	v3 := &v2
-	rv, err := stripPtrs(reflect.ValueOf(v3))
-	assert.Nil(err)
-	assert.Equal(rv.Float(), 1.0)
 }


### PR DESCRIPTION
This PR will rollback breaking changes caused by #28.

AWS SDK for Go V2 PR that highlighted the [issue](https://github.com/aws/aws-sdk-go-v2/pull/89)