### PR TITLE
Fixes issues with accessing fields from data decoded from YAML.

### DIFF
--- a/interpreter.go
+++ b/interpreter.go
@@ -80,6 +80,10 @@ func (intr *treeInterpreter) Execute(node ASTNode, value interface{}) (interface
 			key := node.value.(string)
 			return m[key], nil
 		}
+		if m, ok := value.(map[interface{}]interface{}); ok {
+			key := node.value
+			return m[key], nil
+		}
 		return intr.fieldFromStruct(node.value.(string), value)
 	case ASTFilterProjection:
 		left, err := intr.Execute(node.children[0], value)

--- a/interpreter_test.go
+++ b/interpreter_test.go
@@ -181,6 +181,20 @@ func TestCanSupportSliceOfStructsWithFunctions(t *testing.T) {
 	assert.Equal(result.(float64), 2.0)
 }
 
+func TestYAMLObjects(t *testing.T) {
+	assert := assert.New(t)
+
+	data := map[interface{}]interface{}{
+		"db": map[interface{}]interface{}{
+			"user": "app",
+			"name": "test-db",
+		},
+	}
+	result, err := Search("db.name", data)
+	assert.Nil(err)
+	assert.Equal("test-db", result)
+}
+
 func BenchmarkInterpretSingleFieldStruct(b *testing.B) {
 	intr := newInterpreter()
 	parser := NewParser()


### PR DESCRIPTION
Addresses an issue with decoding values from yaml, namely where `go-yaml` encodes graph nodes as `map[interface{}]interface{}` instead of `map[string]interface{}`.