### PR TITLE
implement simple del function on object

### DIFF
--- a/compliance/functions.json
+++ b/compliance/functions.json
@@ -821,5 +821,20 @@
       "result": [[1, 2, 3, 4], [5, 6, 7, 8, 9]]
     }
   ]
+},
+{
+  "given": {
+    "array": {},
+    "deleteme": "ok",
+    "foo": [1,2,3,4]
+  },
+  "cases": [
+    {
+      "expression": "del(@,'deleteme','foo')",
+      "result": {
+        "array": {}
+      }
+    }
+  ]
 }
 ]

--- a/functions.go
+++ b/functions.go
@@ -319,6 +319,14 @@ func newFunctionCaller() *functionCaller {
 			},
 			handler: jpfNotNull,
 		},
+		"del": {
+			name: "del",
+			arguments: []argSpec{
+				{types: []jpType{jpObject}},
+				{types: []jpType{jpString}, variadic: true},
+			},
+			handler: jpfDel,
+		},
 	}
 	return caller
 }
@@ -482,6 +490,16 @@ func jpfMap(arguments []interface{}) (interface{}, error) {
 	}
 	return mapped, nil
 }
+
+func jpfDel(arguments []interface{}) (interface{}, error) {
+	obj := arguments[0].(map[string]interface{})
+	for i := 1; i < len(arguments); i++ {
+		key := arguments[i].(string)
+		delete(obj, key)
+	}
+	return obj, nil
+}
+
 func jpfMax(arguments []interface{}) (interface{}, error) {
 	if items, ok := toArrayNum(arguments[0]); ok {
 		if len(items) == 0 {


### PR DESCRIPTION
Hey @jamesls,

Thank you for the great project, I was blown away by how clean this was implemented !

This PR introduces a way to delete multiple keys from an object, **I know the PR is probably not semantically something we want for this language** but I wanted it to be a starting point for a discussion on how we could achieve this.

We used jmespath in Grafana Loki to transform and select json, we love it and so far there is no better alternative. Though we would like to be able to delete key from objects because some logs may contains sensitive data or simply are not required. A bit like with jq `del(.foo)`.

There is may be a better way to achieve this or may be we don't want this at all ?

I'm happy to contribute to the project to solve this issue, if we can settle on a design.

Again, Thank you