### PR TITLE
cmaurer: adding tests, fixing aws query issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 jmespath-fuzz.zip
 cpu.out
 go-jmespath.test
+.vscode

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ sudo: false
 go:
   - 1.4
 
-install: go mod tidy
+install: go get -v -t ./...
 
 script: make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: go
 
-sudo: required
-
 os:
     - linux
     - osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,20 @@
 language: go
 
-sudo: false
+sudo: required
+
+os:
+    - linux
+    - osx
 
 go:
-  - 1.4
+  - 1.12.x
+  - 1.13.x
+  - 1.14.x
+  - tip
+
+  matrix:
+    allow_failures:
+        - go: tip
 
 install: go get -v -t ./...
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,6 @@ sudo: false
 go:
   - 1.4
 
-install: go get -v -t ./...
+#install: go get -v -t ./...
+
 script: make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ sudo: false
 go:
   - 1.4
 
-#install: go get -v -t ./...
+install: go mod tidy
 
 script: make test

--- a/compliance/aws_items.json
+++ b/compliance/aws_items.json
@@ -1,0 +1,54 @@
+[{
+    "given": {
+        "Items": [{
+            "Id": "0lby2sr150",
+            "Name": "ExampleAPI",
+            "Description": "Example API",
+            "CreatedDate": 1582562487,
+            "ApiKeySource": "HEADER",
+            "EndpointConfiguration": {
+                "Types": [
+                    "REGIONAL"
+                ]
+            }
+        }]
+    },
+    "cases": [{
+            "comment": "all items",
+            "expression": "Items[]",
+            "result": [{
+                "Id": "0lby2sr150",
+                "Name": "ExampleAPI",
+                "Description": "Example API",
+                "CreatedDate": 1582562487,
+                "ApiKeySource": "HEADER",
+                "EndpointConfiguration": {
+                    "Types": [
+                        "REGIONAL"
+                    ]
+                }
+            }]
+        },
+        {
+            "comment": "query by name",
+            "expression": "Items[?Name==`ExampleAPI`]",
+            "result": [{
+                "Id": "0lby2sr150",
+                "Name": "ExampleAPI",
+                "Description": "Example API",
+                "CreatedDate": 1582562487,
+                "ApiKeySource": "HEADER",
+                "EndpointConfiguration": {
+                    "Types": [
+                        "REGIONAL"
+                    ]
+                }
+            }]
+        },
+        {
+            "comment": "query by name - Id",
+            "expression": "Items[?Name==`ExampleAPI`].Id",
+            "result": ["0lby2sr150"]
+        }
+    ]
+}]

--- a/compliance/aws_users.json
+++ b/compliance/aws_users.json
@@ -1,0 +1,54 @@
+[{
+    "given": {
+        "Users": [{
+                "UserName": "testuser-50",
+                "Path": "/",
+                "CreateDate": "2013-02-12T19:08:52Z",
+                "UserId": "EXAMPLEUSERID",
+                "Arn": "arn:aws:iam::12345:user/testuser1"
+            },
+            {
+                "UserName": "testuser-51",
+                "Path": "/",
+                "CreateDate": "2012-10-14T23:53:39Z",
+                "UserId": "EXAMPLEUSERID",
+                "Arn": "arn:aws:iam::123456:user/testuser2"
+            }
+        ]
+    },
+    "cases": [{
+            "comment": "all users",
+            "expression": "Users[]",
+            "result": [{
+                    "UserName": "testuser-50",
+                    "Path": "/",
+                    "CreateDate": "2013-02-12T19:08:52Z",
+                    "UserId": "EXAMPLEUSERID",
+                    "Arn": "arn:aws:iam::12345:user/testuser1"
+                },
+                {
+                    "UserName": "testuser-51",
+                    "Path": "/",
+                    "CreateDate": "2012-10-14T23:53:39Z",
+                    "UserId": "EXAMPLEUSERID",
+                    "Arn": "arn:aws:iam::123456:user/testuser2"
+                }
+            ]
+        },
+        {
+            "comment": "users username",
+            "expression": "Users[*].UserName",
+            "result": ["testuser-50", "testuser-51"]
+        },
+        {
+            "comment": "zero",
+            "expression": "`0`",
+            "result": 0
+        },
+        {
+            "comment": "specific user",
+            "expression": "Users[?UserName==`testuser-51`].UserName",
+            "result": ["testuser-51"]
+        }
+    ]
+}]

--- a/compliance_test.go
+++ b/compliance_test.go
@@ -40,6 +40,8 @@ var whiteListed = []string{
 	"compliance/unicode.json",
 	"compliance/wildcard.json",
 	"compliance/boolean.json",
+	"compliance/aws_users.json",
+	"compliance/aws_items.json",
 }
 
 func allowed(path string) bool {

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/jmespath/go-jmespath
+
+go 1.14
+
+require github.com/stretchr/testify v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
+github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,7 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/lexer.go
+++ b/lexer.go
@@ -241,6 +241,10 @@ func (lexer *Lexer) consumeUntil(end rune) (string, error) {
 	return lexer.expression[start : lexer.currentPos-lexer.lastWidth], nil
 }
 
+func (lexer *Lexer) isJSON(value string) bool {
+	return json.Valid([]byte(value))
+}
+
 func (lexer *Lexer) consumeLiteral() (token, error) {
 	start := lexer.currentPos
 	value, err := lexer.consumeUntil('`')
@@ -248,8 +252,16 @@ func (lexer *Lexer) consumeLiteral() (token, error) {
 		return token{}, err
 	}
 	value = strings.Replace(value, "\\`", "`", -1)
+	if lexer.isJSON(value) {
+		return token{
+			tokenType: tJSONLiteral,
+			value:     value,
+			position:  start,
+			length:    len(value),
+		}, nil
+	}
 	return token{
-		tokenType: tJSONLiteral,
+		tokenType: tStringLiteral,
 		value:     value,
 		position:  start,
 		length:    len(value),


### PR DESCRIPTION
Some aws cli jmespath queries will fail (see below).

``` Could not parse expression: Items[?Name==`ExampleAPI`] -- invalid character 'E' looking for beginning of value```

The lexer expects anything between backticks \` to be json.  Added a method to check for valid json, if so, it returns a json token, otherwise it returns a string.

Also, added some tests to verify.