### PR TITLE
Add CI test for Go 1.14 and Go tip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,11 @@ go:
   - 1.11.x
   - 1.12.x
   - 1.13.x
+  - 1.14.x
+  - tip
+
+allow_failures:
+  - go: tip
 
 install: go get -v -t ./...
 script: make test


### PR DESCRIPTION
Adds CI tests for Go 1.14. In addition to Go tip that is allowed to fail. Go tip tests are helpful for identifying potentially bugs in the unreleased Go version, or potential incorrect assumptions made about the behavior of the standard library.