### PR TITLE
Update to latest version of testify for updated yaml transient dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/jmespath/go-jmespath
 
 go 1.14
 
-require github.com/stretchr/testify v1.5.1
+require github.com/stretchr/testify v1.6.1


### PR DESCRIPTION
Updates the `github.com/stretchr/testify` dependency to v1.6.1 pulling in the transient dependency update for `gopkg.in/yaml.v2`. The v2 yaml package has vulnerability `CVE-2019-11254`. Updating testify to v1.6.1 pulls in `gopkg.in/yaml.v3` with the vulnerability resolved.