### PR TITLE
Update to use internal testify submodule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,6 @@ help:
 generate:
 	go generate ${SRC_PKGS}
 
-get-deps:
-	go get -v -t ./ ./cmd/... ./compliance/... ./fuzz/...
-
 build:
 	rm -f $(CMD)
 	go build ${SRC_PKGS}

--- a/api_test.go
+++ b/api_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/jmespath/go-jmespath/internal/testify/assert"
 )
 
 func TestValidUncompiledExpressionSearches(t *testing.T) {

--- a/compliance_test.go
+++ b/compliance_test.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/jmespath/go-jmespath/internal/testify/assert"
 )
 
 type TestSuite struct {

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/jmespath/go-jmespath
 
 go 1.14
 
-require github.com/stretchr/testify v1.5.1
+require github.com/jmespath/go-jmespath/internal/testify v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,11 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
-github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
-gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
+gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/interpreter_test.go
+++ b/interpreter_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/jmespath/go-jmespath/internal/testify/assert"
 )
 
 type scalars struct {

--- a/lexer_test.go
+++ b/lexer_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/jmespath/go-jmespath/internal/testify/assert"
 )
 
 var lexingTests = []struct {

--- a/parser_test.go
+++ b/parser_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/jmespath/go-jmespath/internal/testify/assert"
 )
 
 var parsingErrorTests = []struct {

--- a/util_test.go
+++ b/util_test.go
@@ -3,7 +3,7 @@ package jmespath
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/jmespath/go-jmespath/internal/testify/assert"
 )
 
 func TestSlicePositiveStep(t *testing.T) {


### PR DESCRIPTION
Updates go-jmespath to use the internal testify submodule to in order to modify the yaml.v2 version transient dependency of testify. A version of testify that is updated with the yaml.v2 is not compatible with Go 1.12 and older.