### PR TITLE
Add GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: ci
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+env:
+  pkg: github.com/jmespath/go-jmespath
+  GOPATH: "${{ github.workspace }}/go"
+
+jobs:
+  prod:
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        go: [~1.5, ~1.6, ~1.7, ~1.8, ~1.9, ~1.10, ~1.11, ~1.12, ~1.13, ~1.14, ~1.15, 1.16.0-beta1]
+    defaults:
+      run:
+        working-directory: "go/src/github.com/jmespath/go-jmespath"
+    steps:
+      - uses: actions/setup-go@v2
+        with:
+          stable: ${{ !contains(matrix.go, 'beta') && !contains(matrix.go, 'rc') }}
+          go-version: ${{ matrix.go }}
+      - uses: actions/checkout@v2
+        with:
+          path: go/src/github.com/jmespath/go-jmespath
+      - run: go get -d ./...
+      - run: make build
+      - run: make test-prod
+      - run: make check
+
+  internal-testify:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ~1.15
+      - uses: actions/checkout@v2
+      - run: make test-internal-testify

--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,9 @@ build:
 	rm -f cmd/$(CMD)/$(CMD) && cd cmd/$(CMD)/ && go build ./...
 	mv cmd/$(CMD)/$(CMD) .
 
-test: test-internal-testify
-	echo "making tests ${SRC_PKGS}"
+test: test-internal-testify test-prod
+
+test-prod:
 	go test -v ${SRC_PKGS}
 
 check:


### PR DESCRIPTION
With travis.org going away soon, I thought there may be some interest in running ci in GitHub Actions.

This introduces a workflow that tests production code on go versions 1.5 through 1.16beta1.  It tests `internal/testify` only with 1.15.

In order to allow older go versions to run tests on production code, I made a new Makefile target called `test-prod`.
