### PR TITLE
to_number accepts arguments of type json.Number

### DIFF
--- a/functions.go
+++ b/functions.go
@@ -811,6 +811,13 @@ func jpfToNumber(arguments []interface{}) (interface{}, error) {
 	if v, ok := arg.(float64); ok {
 		return v, nil
 	}
+	if v, ok := arg.(json.Number); ok {
+		conv, err := strconv.ParseFloat(string(v), 64)
+		if err != nil {
+			return nil, nil
+		}
+		return conv, nil
+	}
 	if v, ok := arg.(string); ok {
 		conv, err := strconv.ParseFloat(v, 64)
 		if err != nil {


### PR DESCRIPTION
`to_number` implementation fails to cast arguments of the standard type `json.Number`.
All numbers are converted to json.Number (a mere string) when `UseNumber` has been set on the json Decoder.