### PR TITLE
Improved error handling

### DIFF
--- a/compliance_test.go
+++ b/compliance_test.go
@@ -98,6 +98,11 @@ func runSyntaxTestCase(assert *assert.Assertions, given interface{}, testcase Te
 	// an error when we try to evaluate the expression.
 	_, err := Search(testcase.Expression, given)
 	assert.NotNil(err, fmt.Sprintf("Expression: %s", testcase.Expression))
+	if er, ok := err.(SyntaxError); !ok {
+		assert.Fail("unexpected error: %T, %v: %s", err, err, fmt.Sprintf("Expression: %s", testcase.Expression))
+	} else {
+		assert.Equal(testcase.Error, er.Type(), fmt.Sprintf("Expression: %s", testcase.Expression))
+	}
 }
 
 func runTestCase(assert *assert.Assertions, given interface{}, testcase TestCase, filename string) {

--- a/parser_test.go
+++ b/parser_test.go
@@ -11,8 +11,8 @@ var parsingErrorTests = []struct {
 	expression string
 	msg        string
 }{
-	{"foo.", "Incopmlete expression"},
-	{"[foo", "Incopmlete expression"},
+	{"foo.", "Incomplete expression"},
+	{"[foo", "Incomplete expression"},
 	{"]", "Invalid"},
 	{")", "Invalid"},
 	{"}", "Invalid"},

--- a/util.go
+++ b/util.go
@@ -1,7 +1,6 @@
 package jmespath
 
 import (
-	"errors"
 	"reflect"
 )
 
@@ -84,7 +83,10 @@ func computeSliceParams(length int, parts []sliceParam) ([]int, error) {
 	if !parts[2].Specified {
 		step = 1
 	} else if parts[2].N == 0 {
-		return nil, errors.New("Invalid slice, step cannot be 0")
+		return nil, SyntaxError{
+			typ: ErrInvalidValue,
+			msg: "Invalid slice, step cannot be 0",
+		}
 	} else {
 		step = parts[2].N
 	}


### PR DESCRIPTION
This PR improves error handling.

1. Consistently return `SyntaxError`. Previously, some syntax errors were reported as `SyntaxError` and in other cases it was just an error string.
2. Add `typ` field in `SyntaxError`. The `typ` is set to the error string values defined in the JMESpath specification such as `invalid-type` and `unknown-function`.
3. Create constants for error types that are defined in the specification.
4. In compliance tests, validate the actual error type matches the expectation. Previously, the compliance suite was only validating the error is not `nil`.