### PR TITLE
bugfix: to_array parses marshalled json

### DIFF
--- a/compliance/functions.json
+++ b/compliance/functions.json
@@ -468,6 +468,10 @@
       "result": [{"foo": "bar", "bar": "baz"}]
     },
     {
+      "expression": "to_array(to_string(objects))",
+      "result": [{"foo": "bar", "bar": "baz"}]
+    },
+    {
       "expression": "to_array(`[1, 2, 3]`)",
       "result": [1, 2, 3]
     },

--- a/functions.go
+++ b/functions.go
@@ -793,6 +793,13 @@ func jpfToArray(arguments []interface{}) (interface{}, error) {
 	if _, ok := arguments[0].([]interface{}); ok {
 		return arguments[0], nil
 	}
+	if asString, ok := arguments[0].(string); ok {
+		var unmarshalled interface{}
+		err := json.Unmarshal([]byte(asString), &unmarshalled)
+		if err == nil {
+			return []interface{}{unmarshalled}, err
+		}
+	}
 	return arguments[:1:1], nil
 }
 func jpfToString(arguments []interface{}) (interface{}, error) {


### PR DESCRIPTION
According to jmespath's [to_array specification](https://jmespath.org/specification.html#to-array), `to_array` should parse marshalled json. This fixes https://github.com/jmespath/go-jmespath/issues/91.